### PR TITLE
Propongo mejoras de filtrado

### DIFF
--- a/models/account_payment_receipt.py
+++ b/models/account_payment_receipt.py
@@ -58,7 +58,7 @@ class AccountPaymentReceipt(models.Model):
             ("cancelled", "Cancelled"),
         ],
         string="Status",
-        default="draft",
+        default="posted",
         required=True,
     )
 
@@ -84,6 +84,45 @@ class AccountPaymentReceipt(models.Model):
             record.currency_id = (
                 record.company_id.currency_id if record.company_id else False
             )
+
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        if not self.partner_id:
+            self.payment_ids = False
+            self.move_ids = False
+            return
+
+        # Obtener pagos posteados del partner que aún no están en otro recibo
+        used_payment_ids = self.env['account.payment.receipt'].search([]).mapped('payment_ids.id')
+
+        available_payments = self.env['account.payment'].search([
+            ('partner_id', '=', self.partner_id.id),
+            ('state', '=', 'posted'),
+            ('id', 'not in', used_payment_ids),
+        ])
+
+        # Obtener facturas relacionadas con esos pagos
+        invoices = self.env['account.move']
+        for payment in available_payments:
+            payment_lines = payment.move_id.line_ids.filtered(
+                lambda l: l.account_id.account_type in ('asset_receivable', 'liability_payable')
+            )
+            reconciliations = self.env['account.partial.reconcile'].search([
+                '|',
+                ('debit_move_id', 'in', payment_lines.ids),
+                ('credit_move_id', 'in', payment_lines.ids),
+            ])
+            for reconciliation in reconciliations:
+                invoice = (
+                    reconciliation.credit_move_id.move_id
+                    if reconciliation.debit_move_id in payment_lines
+                    else reconciliation.debit_move_id.move_id
+                )
+                if invoice.is_invoice():
+                    invoices |= invoice
+
+        self.payment_ids = available_payments
+        self.move_ids = invoices
 
     def get_payments_by_currency(self):
         """Return payments grouped by currency as a list of (currency, payments) tuples."""

--- a/views/account_payment_receipt_views.xml
+++ b/views/account_payment_receipt_views.xml
@@ -8,7 +8,7 @@
                 <field name="date"/>
                 <field name="partner_id"/>
                 <field name="payment_names"/>
-                <field name="state"/>
+                <!-- <field name="state"/> -->
                 <button
                     name="action_print_receipt"
                     string="Print Receipt"
@@ -30,7 +30,7 @@
                         <field name="name"/>
                         <field name="date"/>
                         <field name="partner_id"/>
-                        <field name="state"/>
+                        <!-- <field name="state"/> -->
                     </group>
                     <group>
                         <field name="payment_names" readonly="1"/>

--- a/views/report_payment_receipt.xml
+++ b/views/report_payment_receipt.xml
@@ -149,8 +149,9 @@
                     </table>
                     <br/>
                 </t>
-                <t t-set="withholdings"
-                   t-value="o.payment_ids.mapped('l10n_ar_withholding_line_ids')"
+                <t t-if="o.payment_ids and 'l10n_ar_withholding_line_ids' in o.payment_ids[0]._fields">
+                    <t t-set="withholdings"
+                        t-value="o.payment_ids.mapped('l10n_ar_withholding_line_ids')"
                 />
                 <table
                     class="table table-sm o_main_table"
@@ -183,6 +184,7 @@
                         </t>
                     </tbody>
                 </table>
+            </t>
                 <br/>
                 <table
                     class="table table-sm o_main_table"


### PR DESCRIPTION
Propongo mejoras de filtrado para que al seleccionar el partner solo devuelva facturas publicadas y cobradas con sus recibos relacionados, y que no hayan sido utilizadas anteriormente en otro recibo de grupo de pagos.